### PR TITLE
Update Metabase to v0.52.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,4 @@
  :aliases
  {:dev
   {:extra-deps
-   {io.github.metabase/metabase {:git/tag "v0.52.1", :git/sha "5bc320b"}}}}}
+   {io.github.metabase/metabase {:git/tag "v0.52.2", :git/sha "32effb1"}}}}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/metabase/metabase:v0.52.1
+FROM docker.io/metabase/metabase:v0.52.2
 
 ADD ./target/greptimedb.metabase-driver.jar plugins/


### PR DESCRIPTION
This PR updates the Metabase version to v0.52.2.